### PR TITLE
[war] Add user-entered totals and end-of-war summaries.

### DIFF
--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -192,12 +192,12 @@ class Rogare::Commands::Wordwar
     types = %w[words lines pages minutes]
     data = id.split(' ')
     check = begin
-              Integer(data[1], 10)
+              data[1].to_i
             rescue StandardError
               nil
             end
     war = War[data[0].to_i]
-    data[2] = 'words' if data[2].nil?
+    data[2] ||= 'words'
 
     return m.reply 'No such wordwar' unless war&.exists?
     return m.reply 'It\'s not over yet' unless war&.finished?

--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -215,7 +215,7 @@ class Rogare::Commands::Wordwar
     return m.reply 'No such wordwar' unless war&.exists?
     return m.reply 'It\'s not over yet' unless war.finished?
 
-    members = war.format_totals(id.to_i)
+    members = war.totals
 
     m.reply "**Statistics for war #{id.to_i}:**\n\n" +
             members.join("\n")

--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -200,12 +200,11 @@ class Rogare::Commands::Wordwar
     data[2] ||= 'words'
 
     return m.reply 'No such wordwar' unless war&.exists?
-    return m.reply 'It\'s not over yet' unless war&.finished?
+    return m.reply 'It\'s not over yet' unless war.finished?
     return m.reply 'That\'s not a valid total' if check.nil?
     return m.reply 'That\'s not a valid type' unless types.include? data[2]
 
     war.add_total(m.user, data[1].to_i, data[2])
-    war.save
 
     m.reply 'Got it!'
   end
@@ -214,7 +213,7 @@ class Rogare::Commands::Wordwar
     war = War[id.to_i]
 
     return m.reply 'No such wordwar' unless war&.exists?
-    return m.reply 'It\'s not over yet' unless war&.finished?
+    return m.reply 'It\'s not over yet' unless war.finished?
 
     members = war.format_totals(id.to_i)
 

--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -11,6 +11,8 @@ class Rogare::Commands::Wordwar
     'Or: `!% at [wall time e.g. 12:35] for [duration]`',
     'Or even (defaulting to a 15 minute run): `!% at/in [time]`',
     'And then everyone should: `!% join [wordwar ID]`',
+    'And add their total at the end with `!% total [ID] [total]`',
+    'Then get the summary with `!% summary [ID]`',
     'Also say `!%` alone to get a list of current/scheduled ones',
     'To get some details about a war: `!% info [ID]` or `!% members [ID]`.'
   ]

--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -189,23 +189,25 @@ class Rogare::Commands::Wordwar
   end
 
   def ex_total_war(m, id)
-    types = ['words', 'lines', 'pages', 'minutes']
+    types = %w[words lines pages minutes]
     data = id.split(' ')
-    check = Integer(data[1], 10) rescue nil
+    check = begin
+              Integer(data[1], 10)
+            rescue StandardError
+              nil
+            end
     war = War[data[0].to_i]
-    if data[2] == nil then
-      data[2] = 'words'
-    end
-    
+    data[2] = 'words' if data[2].nil?
+
     return m.reply 'No such wordwar' unless war&.exists?
     return m.reply 'It\'s not over yet' unless war&.finished?
-    return m.reply 'That\'s not a valid total' unless !check.nil?
+    return m.reply 'That\'s not a valid total' if check.nil?
     return m.reply 'That\'s not a valid type' unless types.include? data[2]
 
     war.add_total(m.user, data[1].to_i, data[2])
     war.save
 
-    m.reply "Got it!"
+    m.reply 'Got it!'
   end
 
   def ex_war_summary(m, id)
@@ -217,6 +219,6 @@ class Rogare::Commands::Wordwar
     members = war.format_totals(id.to_i)
 
     m.reply "**Statistics for war #{id.to_i}:**\n\n" +
-      members.join("\n")
+            members.join("\n")
   end
 end

--- a/commands/wordwar.rb
+++ b/commands/wordwar.rb
@@ -200,7 +200,7 @@ class Rogare::Commands::Wordwar
     data[2] ||= 'words'
 
     return m.reply 'No such wordwar' unless war&.exists?
-    return m.reply 'It\'s not over yet' unless war.finished?
+    return m.reply 'It\'s not over yet' if war.current?
     return m.reply 'That\'s not a valid total' if check.nil?
     return m.reply 'That\'s not a valid type' unless types.include? data[2]
 
@@ -213,7 +213,7 @@ class Rogare::Commands::Wordwar
     war = War[id.to_i]
 
     return m.reply 'No such wordwar' unless war&.exists?
-    return m.reply 'It\'s not over yet' unless war.finished?
+    return m.reply 'It\'s not over yet' if war.current?
 
     members = war.totals
 

--- a/migrations/20180701_wars.rb
+++ b/migrations/20180701_wars.rb
@@ -28,7 +28,7 @@ Sequel.migration do
     comment_on :column, %i[wars started], 'If this war was announced as having started'
     comment_on :column, %i[wars ended], 'If this war was announced as having ended'
 
-    enum types: [:words, :lines, :pages, :minutes]
+    enum types: %i[words lines pages minutes]
 
     create_table(:wars_members) do
       Integer :user_id, null: false

--- a/migrations/20180701_wars.rb
+++ b/migrations/20180701_wars.rb
@@ -28,9 +28,13 @@ Sequel.migration do
     comment_on :column, %i[wars started], 'If this war was announced as having started'
     comment_on :column, %i[wars ended], 'If this war was announced as having ended'
 
+    enum types: [:words, :lines, :pages, :minutes]
+
     create_table(:wars_members) do
       Integer :user_id, null: false
       Integer :war_id, null: false
+      Integer :total, null: true
+      column :total_type, 'types', null: true, default: 'words'
 
       primary_key %i[user_id war_id]
       index %i[war_id user_id], type: 'btree'

--- a/migrations/20180701_wars.rb
+++ b/migrations/20180701_wars.rb
@@ -28,13 +28,9 @@ Sequel.migration do
     comment_on :column, %i[wars started], 'If this war was announced as having started'
     comment_on :column, %i[wars ended], 'If this war was announced as having ended'
 
-    enum types: %i[words lines pages minutes]
-
     create_table(:wars_members) do
       Integer :user_id, null: false
       Integer :war_id, null: false
-      Integer :total, null: true
-      column :total_type, 'types', null: true, default: 'words'
 
       primary_key %i[user_id war_id]
       index %i[war_id user_id], type: 'btree'

--- a/migrations/20190107_wars.rb
+++ b/migrations/20190107_wars.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+    change do
+  
+      enum types: %i[words lines pages minutes]
+  
+      alter_table(:wars_members) do
+        Integer :total, null: true
+        column :total_type, 'types', null: true, default: 'words'
+        
+      end
+    end
+  end
+  

--- a/migrations/20190107_wars.rb
+++ b/migrations/20190107_wars.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-    change do
-  
-      enum types: %i[words lines pages minutes]
-  
-      alter_table(:wars_members) do
-        Integer :total, null: true
-        column :total_type, 'types', null: true, default: 'words'
-        
-      end
+  change do
+    enum types: %i[words lines pages minutes]
+
+    alter_table(:wars_members) do
+      Integer :total, null: true
+      column :total_type, 'types', null: true, default: 'words'
     end
   end
-  
+end

--- a/models/war.rb
+++ b/models/war.rb
@@ -97,7 +97,7 @@ class War < Sequel::Model
     member.save
   end
 
-  def format_totals(id)
+  def totals
     memberships_dataset.eager(:user)
     members.map do |m|
       "#{m.user.mid}: **#{m.total}** #{m.total_type} (**" \

--- a/models/war.rb
+++ b/models/war.rb
@@ -94,19 +94,19 @@ class War < Sequel::Model
 
   def add_total(user, total, type)
     add_member! user
-    
-    WarMember.where(user_id: user.id, war_id: self.id).update(total: total, total_type: type)
+
+    WarMember.where(user_id: user.id, war_id: id).update(total: total, total_type: type)
   end
-  
-  def get_totals(id)
-    return memberships_dataset.eager(:user)
+
+  def get_totals(_id)
+    memberships_dataset.eager(:user)
   end
 
   def format_totals(id)
     members = get_totals(id)
     members.map do |m|
-      "#{m.user.mid}: **#{m.total}** #{m.total_type} (**" +
-      "#{(m.total.to_f / (self.seconds / 60)).round(2)}** #{m.total_type} per minute)"
+      "#{m.user.mid}: **#{m.total}** #{m.total_type} (**" \
+        "#{(m.total.to_f / (seconds / 60)).round(2)}** #{m.total_type} per minute)"
     end
   end
 

--- a/models/war.rb
+++ b/models/war.rb
@@ -47,10 +47,6 @@ class War < Sequel::Model
     current? && start > Time.now
   end
 
-  def finished?
-    exists? && finish < Time.now
-  end
-
   def others
     members.reject { |u| u == creator }
   end
@@ -101,12 +97,8 @@ class War < Sequel::Model
     member.save
   end
 
-  def get_totals(_id)
-    memberships_dataset.eager(:user)
-  end
-
   def format_totals(id)
-    members = get_totals(id)
+    memberships_dataset.eager(:user)
     members.map do |m|
       "#{m.user.mid}: **#{m.total}** #{m.total_type} (**" \
         "#{(m.total.to_f / (seconds / 60)).round(2)}** #{m.total_type} per minute)"

--- a/models/war.rb
+++ b/models/war.rb
@@ -95,7 +95,10 @@ class War < Sequel::Model
   def add_total(user, total, type)
     add_member! user
 
-    WarMember.where(user_id: user.id, war_id: id).update(total: total, total_type: type)
+    member = WarMember[user_id: user.id, war_id: id]
+    member.total = total
+    member.total_type = type
+    member.save
   end
 
   def get_totals(_id)

--- a/models/war.rb
+++ b/models/war.rb
@@ -98,8 +98,7 @@ class War < Sequel::Model
   end
 
   def totals
-    memberships_dataset.eager(:user)
-    members.map do |m|
+    memberships_dataset.eager(:user).map do |m|
       "#{m.user.mid}: **#{m.total}** #{m.total_type} (**" \
         "#{(m.total.to_f / (seconds / 60)).round(2)}** #{m.total_type} per minute)"
     end


### PR DESCRIPTION
This pull request adds the facility for users to enter a total at the end of a war using !ww total [id] [total] [words|lines|pages|minutes], and view a summary of all entered totals using !ww summary [id].

This pull request requires a database refresh, due to the addition of the `total` and `total_type` fields to the wars_members table.