### PR TITLE
Remove hard coded "now playing" list in favour of a database-backed list

### DIFF
--- a/lib/rogare/core.rb
+++ b/lib/rogare/core.rb
@@ -32,55 +32,7 @@ module Rogare
     end
 
     def game
-      [
-        'with fire',
-        'at life — and winning',
-        'Plotting in the Dark',
-        'Killing Characters',
-        'Taking names and kicking ass',
-        'Breaking quills',
-        'Pulling out the full stops',
-        'with cute animals',
-        'Destiny… of your MC',
-        'the role of Fate',
-        'Shadow puppets',
-        'with your wordcount',
-        'World of Wordcraft',
-        'Plot Hole Hunters',
-        'Age of Myth',
-        'League of Writers',
-        'the fool',
-        'and drinking',
-        'Really old scrolls VI',
-        'you',
-        'Grand Write Into',
-        'Legend of Making Count',
-        'Writer’s DOOM',
-        'Two Fortnites (and this will be over)',
-        'Red Pen Redemption',
-        'Finally Fantasy',
-        'CoD: Blank Page',
-        'Dots 2',
-        'Half-Novel²',
-        'Poketome Go',
-        'Wordsmith’s Creed: Odyssey',
-        'Plotfinder: Kingmaker',
-        'and wandering and lusting',
-        'Super Script Bros',
-        'Tom Clancy’s The Pagebreak 2',
-        'Kingdom Inks III',
-        'Wolfenstein: YA debut',
-        'Ori and the Will of the Writs',
-        'Scribe of Solitude',
-        'Dashen',
-        'Presscalibur',
-        'Civilization VI: Gathering Dust',
-        'mind games',
-        'tricks',
-        'Eat The Bug',
-        'woolgathering',
-        'no, no, I’m writing, honest'
-      ].sample
+      Game.random_text
     end
 
     # Extremely short-lived global cache for initial user lookups.

--- a/migrations/20200422_games.rb
+++ b/migrations/20200422_games.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:games) do
+      Integer :id, identity: true, primary_key: true
+
+      foreign_key :creator_id, :users, null: true
+      TrueClass :enabled, null: false, default: true
+      String :text, null: false
+    end
+
+    comment_on :column, %i[games creator_id], "The ID of the user who created this entry"
+    comment_on :column, %i[games enabled], "Whether this now playing entry is used in the bot game rotation"
+    comment_on :column, %i[games text], "The text to display in the game field of the bot's Discord profile"
+  end
+
+  down do
+    drop_table(:games)
+  end
+end

--- a/models/game.rb
+++ b/models/game.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Game < Sequel::Model
+  def self.random_text
+    enabled = where(enabled: true).all
+    return nil if enabled.empty?
+
+    enabled.sample.text
+  end
+
+  def display
+    user_obj = User[creator_id]
+    user = user_obj&.nick ? user_obj.nixnotif : 'somebody'
+    indicator = enabled ? 'on' : 'off'
+
+    "[`#{id}` - #{indicator}]: `#{text}` (added by #{user})"
+  end
+end


### PR DESCRIPTION
Allows for in-Discord management of the bot "now playing" list.

The existing list (removed from the code by this PR) will have to be manually imported into the database for Rogare to perform any changes to the bot now playing status, however since that's done in Garrire for NZ NaNo it doesn't matter too much.

## Internals

- Removes the hard-coded list from `Rogare.game`
- Changes `Rogare.game` to just call `Game#random_text`
- `Game#random_text` selects a random enabled entry from the database and returns it's text

## Commands

- Renames `!bot game` to `!bot game cycle`
- Adds `!bot game list` to list stored entries
- Adds `!bot game add <text>` to add a new entry
- Adds `!bot game delete <id>` to remove an entry
- Adds `!bot game toggle <id>` to toggle whether an entry is used in the rotation of games