### PR TITLE
Fix stored Discord nick never being updated

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -34,7 +34,7 @@ class User < Sequel::Model
     # keep same updated stamp unless we actually update something
     self.updated = updated unless nick != discord_nick
     self.last_seen = Time.now
-    self.nick = nick
+    self.nick = discord_nick
     save
 
     self


### PR DESCRIPTION
Tiny change. When updating a user's nick in `User#seen!` it used the existing database nick rather than the one sent in by Discord.